### PR TITLE
[Memory-opti:fix leak] Fix WorldClient memory leak

### DIFF
--- a/src/main/java/mods/battlegear2/client/renderer/BowRenderer.java
+++ b/src/main/java/mods/battlegear2/client/renderer/BowRenderer.java
@@ -77,7 +77,7 @@ public class BowRenderer implements IItemRenderer {
         } else if (entityLivingBase instanceof EntitySkeleton) {
             arrowStack = MobHookContainerClass.INSTANCE.getArrowForMob((EntitySkeleton) entityLivingBase);
             drawArrows = true;
-        } else if (entityLivingBase == null || entityLivingBase.equals(BattlegearRenderHelper.dummyEntity)) {
+        } else if (entityLivingBase == null) {
             arrowStack = null;
         }
 

--- a/src/main/java/mods/battlegear2/client/renderer/BowRendererDiamond.java
+++ b/src/main/java/mods/battlegear2/client/renderer/BowRendererDiamond.java
@@ -78,7 +78,7 @@ public class BowRendererDiamond implements IItemRenderer {
         } else if (entityLivingBase instanceof EntitySkeleton) {
             arrowStack = MobHookContainerClass.INSTANCE.getArrowForMob((EntitySkeleton) entityLivingBase);
             drawArrows = true;
-        } else if (entityLivingBase == null || entityLivingBase.equals(BattlegearRenderHelper.dummyEntity)) {
+        } else if (entityLivingBase == null) {
             arrowStack = null;
         }
 

--- a/src/main/java/mods/battlegear2/client/renderer/BowRendererIron.java
+++ b/src/main/java/mods/battlegear2/client/renderer/BowRendererIron.java
@@ -78,7 +78,7 @@ public class BowRendererIron implements IItemRenderer {
         } else if (entityLivingBase instanceof EntitySkeleton) {
             arrowStack = MobHookContainerClass.INSTANCE.getArrowForMob((EntitySkeleton) entityLivingBase);
             drawArrows = true;
-        } else if (entityLivingBase == null || entityLivingBase.equals(BattlegearRenderHelper.dummyEntity)) {
+        } else if (entityLivingBase == null) {
             arrowStack = null;
         }
 

--- a/src/main/java/mods/battlegear2/client/renderer/QuiverItremRenderer.java
+++ b/src/main/java/mods/battlegear2/client/renderer/QuiverItremRenderer.java
@@ -11,7 +11,6 @@ import net.minecraftforge.client.IItemRenderer;
 
 import org.lwjgl.opengl.GL11;
 
-import mods.battlegear2.client.utils.BattlegearRenderHelper;
 import mods.battlegear2.items.ItemQuiver;
 import xonin.backhand.api.core.BackhandUtils;
 
@@ -71,11 +70,7 @@ public class QuiverItremRenderer implements IItemRenderer {
             case EQUIPPED:
             case EQUIPPED_FIRST_PERSON:
                 if (data.length > 1 && data[1] instanceof EntityLivingBase livingBase) {
-                    if (livingBase.equals(BattlegearRenderHelper.dummyEntity)) {
-                        // Doesn't render sheathed
-                        GL11.glPopMatrix();
-                        return;
-                    } else if (livingBase instanceof EntityPlayer player && BackhandUtils.isUsingOffhand(player)) {
+                    if (livingBase instanceof EntityPlayer player && BackhandUtils.isUsingOffhand(player)) {
                         // Doesn't render in offhand
                         GL11.glPopMatrix();
                         return;

--- a/src/main/java/mods/battlegear2/client/utils/BattlegearRenderHelper.java
+++ b/src/main/java/mods/battlegear2/client/utils/BattlegearRenderHelper.java
@@ -11,7 +11,6 @@ import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.entity.RenderPlayer;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.passive.EntityChicken;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
@@ -37,7 +36,6 @@ public final class BattlegearRenderHelper {
     private static final ItemStack dummyStack = new ItemStack(Blocks.flowing_lava);
     public static final float RENDER_UNIT = 1F / 16F; // 0.0625
     public static float PROGRESS_INCREMENT_LIMIT = 0.4F;
-    public static EntityLivingBase dummyEntity;
 
     private static final ResourceLocation ITEM_GLINT = new ResourceLocation("textures/misc/enchanted_item_glint.png");
     private static final ResourceLocation DEFAULT_ARROW = new ResourceLocation("textures/entity/arrow.png");
@@ -65,12 +63,6 @@ public final class BattlegearRenderHelper {
     public static void renderItemInFirstPerson(float frame, Minecraft mc, ItemRenderer itemRenderer) {
         GL11.glPopMatrix();
         GL11.glCullFace(GL11.GL_BACK);
-        if (dummyEntity == null) {
-            dummyEntity = new EntityChicken(mc.theWorld);
-        }
-        if (dummyEntity.worldObj != mc.theWorld) {
-            dummyEntity = new EntityChicken(mc.theWorld);
-        }
 
         IOffhandRender offhandRender = (IOffhandRender) itemRenderer;
 
@@ -118,9 +110,6 @@ public final class BattlegearRenderHelper {
                 GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
             }
 
-            float var11;
-            float var12;
-            float var13;
             RenderPlayer var26 = (RenderPlayer) RenderManager.instance.getEntityRenderObject(mc.thePlayer);
             RenderPlayerEvent preRender = new RenderPlayerEvent.Pre(player, var26, frame);
             RenderPlayerEvent postRender = new RenderPlayerEvent.Post(player, var26, frame);


### PR DESCRIPTION
The BattlegearRenderHelper class has a static EntityLivingEntity that is created but never used therefore keeping a reference to the entire WorldClient object.

I just deleted it

![image](https://github.com/user-attachments/assets/615180e0-aac6-4b5b-94cd-21761b4dddf9)
