### PR TITLE
Fix shield arrows

### DIFF
--- a/src/main/java/mods/battlegear2/api/shield/IArrowDisplay.java
+++ b/src/main/java/mods/battlegear2/api/shield/IArrowDisplay.java
@@ -12,7 +12,11 @@ import mods.battlegear2.items.ItemShield;
  */
 public interface IArrowDisplay {
 
+    String NBT_KEY_DISABLED = "disabled";
+
     public void setArrowCount(ItemStack stack, int count);
 
     public int getArrowCount(ItemStack stack);
+
+    public boolean isDisabled(ItemStack stack);
 }

--- a/src/main/java/mods/battlegear2/client/renderer/ShieldRenderer.java
+++ b/src/main/java/mods/battlegear2/client/renderer/ShieldRenderer.java
@@ -46,8 +46,7 @@ public class ShieldRenderer implements IItemRenderer, IOffhandRenderOptOut {
         float blue = (float) (col & 255) / 255.0F;
 
         IIcon icon = item.getIconIndex();
-
-        // break = render arrows, return = no arrows
+        
         switch (type) {
             case ENTITY:
                 GL11.glPushMatrix();

--- a/src/main/java/mods/battlegear2/client/renderer/ShieldRenderer.java
+++ b/src/main/java/mods/battlegear2/client/renderer/ShieldRenderer.java
@@ -46,7 +46,7 @@ public class ShieldRenderer implements IItemRenderer, IOffhandRenderOptOut {
         float blue = (float) (col & 255) / 255.0F;
 
         IIcon icon = item.getIconIndex();
-        
+
         switch (type) {
             case ENTITY:
                 GL11.glPushMatrix();

--- a/src/main/java/mods/battlegear2/client/utils/BattlegearRenderHelper.java
+++ b/src/main/java/mods/battlegear2/client/utils/BattlegearRenderHelper.java
@@ -368,11 +368,13 @@ public final class BattlegearRenderHelper {
         GL11.glDisable(GL11.GL_BLEND);
         GL11.glEnable(GL11.GL_LIGHTING);
         GL11.glDepthFunc(GL11.GL_LEQUAL);
+        GL11.glColor3f(1, 1, 1); // Fixes weird color of Arrows
     }
 
     public static void renderArrows(ItemStack stack, boolean isEntity) {
-        if (stack.getItem() instanceof IArrowDisplay) {
-            int arrowCount = ((IArrowDisplay) stack.getItem()).getArrowCount(stack);
+        if (stack.getItem() instanceof IArrowDisplay arrowDisplay) {
+            if (arrowDisplay.isDisabled(stack)) return;
+            int arrowCount = arrowDisplay.getArrowCount(stack);
             // Bounds checking (rendering this many is quite silly, any more would look VERY silly)
             if (arrowCount > 64) arrowCount = 64;
             for (int i = 0; i < arrowCount; i++) {
@@ -404,7 +406,6 @@ public final class BattlegearRenderHelper {
 
         GL11.glRotatef(pitch, 0, 1, 0);
         GL11.glRotatef(yaw, 1, 0, 0);
-        GL11.glNormal3f(f10, 0, 0);
 
         double f2 = 12F / 32F * depth;
         double f5 = 5 / 32.0F;

--- a/src/main/java/mods/battlegear2/items/ItemShield.java
+++ b/src/main/java/mods/battlegear2/items/ItemShield.java
@@ -182,7 +182,7 @@ public class ItemShield extends Item
             boolean par4) {
         super.addInformation(par1ItemStack, par2EntityPlayer, par3List, par4);
 
-        par3List.add("");
+        par3List.add(StatCollector.translateToLocal("attribute.shield.tooltip"));
 
         par3List.add(
                 EnumChatFormatting.DARK_GREEN + StatCollector.translateToLocalFormatted(

--- a/src/main/java/mods/battlegear2/items/ItemShield.java
+++ b/src/main/java/mods/battlegear2/items/ItemShield.java
@@ -11,10 +11,12 @@ import net.minecraft.entity.projectile.EntityArrow;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.StatCollector;
+import net.minecraft.world.World;
 
 import cpw.mods.fml.common.IFuelHandler;
 import cpw.mods.fml.common.registry.GameRegistry;
@@ -30,6 +32,7 @@ import mods.battlegear2.api.shield.IShield;
 import mods.battlegear2.api.shield.ShieldType;
 import mods.battlegear2.enchantments.BaseEnchantment;
 import mods.battlegear2.utils.BattlegearConfig;
+import xonin.backhand.api.core.BackhandUtils;
 
 public class ItemShield extends Item
         implements IShield, IDyable, IEnchantable, ISheathed, IArrowCatcher, IArrowDisplay, IFuelHandler {
@@ -93,6 +96,34 @@ public class ItemShield extends Item
         }
 
         stack.getTagCompound().setShort("arrows", (short) count);
+    }
+
+    // Disable Arrows (enabled by default)
+    @Override
+    public boolean isDisabled(ItemStack stack) {
+        return stack.getTagCompound() != null && stack.getTagCompound().getBoolean(NBT_KEY_DISABLED);
+    }
+
+    @Override
+    public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player) {
+        if (!world.isRemote && player.isSneaking()) {
+            if (!BackhandUtils.isUsingOffhand(player)) {
+                NBTTagCompound tag = stack.getTagCompound();
+                if (tag == null) {
+                    tag = new NBTTagCompound();
+                    stack.setTagCompound(tag);
+                }
+
+                boolean disabled = tag.getBoolean(NBT_KEY_DISABLED);
+                disabled = !disabled;
+                tag.setBoolean(NBT_KEY_DISABLED, disabled);
+
+                String state = disabled ? EnumChatFormatting.RED + "Disabled" : EnumChatFormatting.GREEN + "Enabled";
+
+                player.addChatMessage(new ChatComponentText(state + " Shield Arrows"));
+            }
+        }
+        return stack;
     }
 
     public IIcon getBackIcon() {
@@ -163,6 +194,14 @@ public class ItemShield extends Item
             par3List.add(
                     EnumChatFormatting.GOLD
                             + StatCollector.translateToLocalFormatted("attribute.shield.arrow.count", arrowCount));
+
+            boolean enabled = !isDisabled(par1ItemStack);
+            String display = enabled ? EnumChatFormatting.GREEN + StatCollector.translateToLocal("options.on")
+                    : EnumChatFormatting.RED + StatCollector.translateToLocal("options.off");
+            par3List.add(
+                    EnumChatFormatting.GOLD + StatCollector.translateToLocalFormatted(
+                            "attribute.shield.arrow.state",
+                            display + EnumChatFormatting.WHITE));
         }
     }
 

--- a/src/main/resources/assets/battlegear2/lang/en_US.lang
+++ b/src/main/resources/assets/battlegear2/lang/en_US.lang
@@ -122,6 +122,7 @@ attribute.name.weapon.extendedReach=Reach
 attribute.name.weapon.attackSpeed=Attack Speed
 attribute.name.weapon.backstab=Backstab
 attribute.name.weapon.mountedBonus=Mounted Damage
+attribute.shield.tooltip=Equip in offhand to use
 attribute.shield.block.time=%s s Block
 attribute.shield.arrow.count=%s Arrows
 attribute.shield.arrow.state=Display Arrows: %s (Sneak + Right Click while holding to toggle)

--- a/src/main/resources/assets/battlegear2/lang/en_US.lang
+++ b/src/main/resources/assets/battlegear2/lang/en_US.lang
@@ -124,6 +124,7 @@ attribute.name.weapon.backstab=Backstab
 attribute.name.weapon.mountedBonus=Mounted Damage
 attribute.shield.block.time=%s s Block
 attribute.shield.arrow.count=%s Arrows
+attribute.shield.arrow.state=Display Arrows: %s (Sneak + Right Click while holding to toggle)
 attribute.quiver.arrow.empty=Empty
 attribute.quiver.arrow.count=Arrows
 


### PR DESCRIPTION
I was originally only going to fix the issue with the arrows, but while testing it, i came across a bunch more issues, which seemed simple enough to fix.

- Fix Arrows rendering where they shouldn't be (Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20438)
- Add a way to disable Shield arrows from rendering (shift + right click while holding disables the arrow rendering, as described in the tooltip)
- Render Shields when they are held in your hand (not the fancy 3D render like in the offhand, but just so that your hand isn't invisible)
- Fix Enchantment Glint of held Shields in 1st person
- Fix Enchantment Glint of dropped Shields having the wrong offset
- Fix Arrows having a purple tint if the shield is enchanted
- Fix dropped Shields rendering Arrows (not sure if this is intentional or not, but the arrows were disproportionately large to the shield and looked kinda ugly)
- Added "Equip in offhand to use" to the tooltip


<img width="720" height="480" alt="2025-08-06_03 02 16" src="https://github.com/user-attachments/assets/1395dc48-1ea8-41c5-8c56-54b5c9d1adc7" />
