### PR TITLE
Allow Thaumcraft's Primal Arrows to be used from the Quiver

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,5 +3,6 @@
 dependencies {
     api('com.github.GTNewHorizons:Backhand:1.8.0:dev')
     compileOnly('curse.maven:dynamic-lights-227874:2337326')
+    compileOnly('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
     devOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.0-GTNH:dev")
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,5 +4,5 @@ dependencies {
     api('com.github.GTNewHorizons:Backhand:1.8.0:dev')
     compileOnly('curse.maven:dynamic-lights-227874:2337326')
     compileOnly('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
-    devOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.0-GTNH:dev")
+    devOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.6-GTNH:dev")
 }

--- a/src/main/java/mods/battlegear2/Battlegear.java
+++ b/src/main/java/mods/battlegear2/Battlegear.java
@@ -32,6 +32,7 @@ import mods.battlegear2.api.weapons.WeaponRegistry;
 import mods.battlegear2.gui.BattlegearGUIHandeler;
 import mods.battlegear2.packet.BattlegearPacketHandeler;
 import mods.battlegear2.utils.BattlegearConfig;
+import mods.battlegear2.utils.ModCompat;
 
 @Mod(
         acceptedMinecraftVersions = "[1.7.10]",
@@ -78,6 +79,7 @@ public class Battlegear {
         packetHandler = new BattlegearPacketHandeler();
         packetHandler.register();
         NetworkRegistry.INSTANCE.registerGuiHandler(this, new BattlegearGUIHandeler());
+        ModCompat.init(event);
     }
 
     @Mod.EventHandler

--- a/src/main/java/mods/battlegear2/utils/ModCompat.java
+++ b/src/main/java/mods/battlegear2/utils/ModCompat.java
@@ -1,0 +1,51 @@
+package mods.battlegear2.utils;
+
+import static thaumcraft.common.config.ConfigItems.itemPrimalArrow;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.projectile.EntityArrow;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.event.FMLInitializationEvent;
+import mods.battlegear2.api.quiver.IArrowFireHandler;
+import mods.battlegear2.api.quiver.QuiverArrowRegistry;
+import thaumcraft.common.entities.projectile.EntityPrimalArrow;
+import thaumcraft.common.items.equipment.ItemPrimalArrow;
+
+public class ModCompat {
+
+    /*
+     * Note when registering arrows for the quiver: Other mods should prefer registering using IMC, through
+     * FMLInterModComms.sendMessage("battlegear2", "Arrow", itemStack) if possible. Registration here should be focused
+     * on mods no modifiable source code.
+     */
+
+    public static void init(FMLInitializationEvent event) {
+        registerThaumcraftCompat();
+    }
+
+    private static void registerThaumcraftCompat() {
+        if (!Loader.isModLoaded("Thaumcraft")) return;
+
+        // Allow TC arrows in Quiver
+        boolean thaumcraftHandlerRegistered = QuiverArrowRegistry.addArrowFireHandler(new IArrowFireHandler() {
+
+            @Override
+            public boolean canFireArrow(ItemStack arrow, World world, EntityPlayer player, float charge) {
+                return arrow.getItem() instanceof ItemPrimalArrow;
+            }
+
+            @Override
+            public EntityArrow getFiredArrow(ItemStack arrow, World world, EntityPlayer player, float charge) {
+                if (!(arrow.getItem() instanceof ItemPrimalArrow)) return null;
+                return new EntityPrimalArrow(world, player, charge, arrow.getItemDamage());
+            }
+        });
+
+        if (thaumcraftHandlerRegistered) {
+            QuiverArrowRegistry.addArrowToRegistry(itemPrimalArrow, null);
+        }
+    }
+}


### PR DESCRIPTION
Allows Thaumcraft's arrows to be placed inside and be usable from the quiver.

<img width="660" height="326" alt="image" src="https://github.com/user-attachments/assets/67d2b168-b16e-448a-8c07-6de4b7e6a52a" />

I'm planning on doing Et Futurum's arrows next, but that'll be a separate PR in the EFR repo.